### PR TITLE
chore: add datadog tracing library

### DIFF
--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -11,6 +11,8 @@ FROM tomcat:jre17
 
 # Copy WAR file
 COPY --from=builder /build/app/build/libs/vss-1.0.war /usr/local/tomcat/webapps/vss.war
+# Add datadog agent for APM
+ADD 'https://dtdg.co/latest-java-tracer' dd-java-agent.jar
 
 EXPOSE 8080
 CMD ["catalina.sh", "run"]

--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -11,7 +11,7 @@ FROM tomcat:jre17
 
 # Copy WAR file
 COPY --from=builder /build/app/build/libs/vss-1.0.war /usr/local/tomcat/webapps/vss.war
-# Add datadog agent for APM
+# Add datadog tracing library for APM
 ADD 'https://dtdg.co/latest-java-tracer' dd-java-agent.jar
 
 EXPOSE 8080

--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -12,7 +12,7 @@ FROM tomcat:jre17
 # Copy WAR file
 COPY --from=builder /build/app/build/libs/vss-1.0.war /usr/local/tomcat/webapps/vss.war
 # Add datadog tracing library for APM
-ADD 'https://dtdg.co/latest-java-tracer' dd-java-agent.jar
+ADD 'https://dtdg.co/latest-java-tracer' /dd-java-agent.jar
 
 EXPOSE 8080
 CMD ["catalina.sh", "run"]


### PR DESCRIPTION
We need to still set the datadog env variables https://docs.datadoghq.com/tracing/trace_collection/automatic_instrumentation/dd_libraries/java/?tab=dockerfile

and also JAVA_OPTS=-javaagent:/path/to/dd-java-agent.jar

(Both in the alby deployment repository)